### PR TITLE
feat: allow the use of an existing kms key

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ module "bootstrap" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | account\_alias | The desired AWS account alias. | `string` | n/a | yes |
+| bucket\_key\_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
 | bucket\_purpose | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
 | dynamodb\_point\_in\_time\_recovery | Point-in-time recovery options | `bool` | `false` | no |
 | dynamodb\_table\_name | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
 | dynamodb\_table\_tags | Tags of the DynamoDB Table for locking Terraform state. | `map(string)` | ```{ "Automation": "Terraform", "Name": "terraform-state-lock" }``` | no |
 | enable\_s3\_public\_access\_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
+| kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption of the state bucket. | `string` | `null` | no |
 | log\_bucket\_tags | Tags to associate with the bucket storing the Terraform state bucket logs | `map(string)` | ```{ "Automation": "Terraform" }``` | no |
 | log\_bucket\_versioning | A string that indicates the versioning status for the log bucket. | `string` | `"Disabled"` | no |
 | log\_name | Log name (for backwards compatibility this can be modified to logs) | `string` | `"log"` | no |

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,9 @@ module "terraform_state_bucket" {
   logging_bucket = local.logging_bucket
 
   use_account_alias_prefix = false
+  bucket_key_enabled       = true
+  kms_master_key_id        = var.kms_master_key_id
+  sse_algorithm            = var.kms_master_key_id != null ? "aws:kms" : null
 
   enable_s3_public_access_block = var.enable_s3_public_access_block
   tags                          = var.state_bucket_tags

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,15 @@ variable "manage_account_alias" {
   default     = true
   description = "Manage the account alias as a resource. Set to 'false' if this behavior is not desired."
 }
+
+variable "kms_master_key_id" {
+  type        = string
+  default     = null
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption of the state bucket."
+}
+
+variable "bucket_key_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
+}


### PR DESCRIPTION
## Description
Allow the use of an existing KMS key to encrypt the state bucket. The values are passed directly to the S3 module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
